### PR TITLE
タブのSTOPタップ時の処理を実装

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -520,16 +520,23 @@ struct R: Rswift.Validatable {
       fileprivate init() {}
     }
     
-    /// This `R.string.mapView` struct is generated, and contains static references to 2 localization keys.
+    /// This `R.string.mapView` struct is generated, and contains static references to 3 localization keys.
     struct mapView {
       /// Value: タイトルを入力してください。
       static let inputTitleMessage = Rswift.StringResource(key: "inputTitleMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
+      /// Value: 位置情報の計測を停止しますか？
+      static let stopUpdatingLocationMessage = Rswift.StringResource(key: "stopUpdatingLocationMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       /// Value: 既に同名のタイトルがあります。タイトルを変更してください。
       static let alreadySameTitleErrorMessage = Rswift.StringResource(key: "alreadySameTitleErrorMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       
       /// Value: タイトルを入力してください。
       static func inputTitleMessage(_: Void = ()) -> String {
         return NSLocalizedString("inputTitleMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
+      }
+      
+      /// Value: 位置情報の計測を停止しますか？
+      static func stopUpdatingLocationMessage(_: Void = ()) -> String {
+        return NSLocalizedString("stopUpdatingLocationMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
       }
       
       /// Value: 既に同名のタイトルがあります。タイトルを変更してください。
@@ -593,10 +600,10 @@ struct _R: Rswift.Validatable {
       
       static func validate() throws {
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/R.generated.swift
+++ b/R.generated.swift
@@ -600,10 +600,10 @@ struct _R: Rswift.Validatable {
       
       static func validate() throws {
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/R.generated.swift
+++ b/R.generated.swift
@@ -600,10 +600,10 @@ struct _R: Rswift.Validatable {
       
       static func validate() throws {
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/footStepMeter/Resources/MapView.strings
+++ b/footStepMeter/Resources/MapView.strings
@@ -1,5 +1,6 @@
 // アラートメッセージ
-"inputTitleMessage"="タイトルを入力してください。";
+"inputTitleMessage" = "タイトルを入力してください。";
+"stopUpdatingLocationMessage" = "位置情報の計測を停止しますか？";
 
 // エラーメッセージ
-"alreadySameTitleErrorMessage"="既に同名のタイトルがあります。タイトルを変更してください。";
+"alreadySameTitleErrorMessage" = "既に同名のタイトルがあります。タイトルを変更してください。";

--- a/footStepMeter/View/MapViewController.swift
+++ b/footStepMeter/View/MapViewController.swift
@@ -100,10 +100,15 @@ extension MapViewController {
                         guard let element = event.element else { return }
                         let alertActionType: AlertActionType = element.0
                         let dataTitle: String? = element.1
-                        // 位置情報の取得精度, アラートの選択アクション, 入力タイトルをViewModelに伝える
-                        Observable.just((locationAccuracy, alertActionType, dataTitle))
-                            .bind(to: strongSelf.viewModel.startUpdatingLocation)
-                            .disposed(by: strongSelf.disposeBag)
+                        switch alertActionType {
+                        case .ok:
+                            // 位置情報の取得精度, アラートの選択アクション, 入力タイトルをViewModelに伝える
+                            Observable.just((locationAccuracy, dataTitle))
+                                .bind(to: strongSelf.viewModel.startUpdatingLocation)
+                                .disposed(by: strongSelf.disposeBag)
+                        case .cancel:
+                            break
+                        }
                     })
                     .disposed(by: strongSelf.disposeBag)
             })

--- a/footStepMeter/View/MapViewController.xib
+++ b/footStepMeter/View/MapViewController.xib
@@ -28,7 +28,7 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <items>
                         <tabBarItem title="START" image="Start" id="h0x-PA-GUg"/>
-                        <tabBarItem tag="1" title="STOP" image="Stop" id="Uef-6t-GFq"/>
+                        <tabBarItem tag="1" enabled="NO" title="STOP" image="Stop" id="Uef-6t-GFq"/>
                         <tabBarItem tag="2" title="FOOT VIEW" image="View" id="XJ6-2E-EdA"/>
                         <tabBarItem tag="3" title="SETTINGS" image="Settings" id="wqB-Gl-L68"/>
                     </items>
@@ -86,10 +86,10 @@
         </view>
     </objects>
     <resources>
-        <image name="Location" width="36" height="36"/>
-        <image name="Settings" width="24" height="24"/>
-        <image name="Start" width="24" height="24"/>
-        <image name="Stop" width="24" height="24"/>
-        <image name="View" width="24" height="24"/>
+        <image name="Location" width="108" height="108"/>
+        <image name="Settings" width="72" height="72"/>
+        <image name="Start" width="72" height="72"/>
+        <image name="Stop" width="72" height="72"/>
+        <image name="View" width="72" height="72"/>
     </resources>
 </document>

--- a/footStepMeter/ViewModel/MapViewModel.swift
+++ b/footStepMeter/ViewModel/MapViewModel.swift
@@ -27,7 +27,7 @@ final class MapViewModel: Injectable {
 
     // MARK: PublishSubjects
     private let startUpdatingLocationStream = PublishSubject<(LocationAccuracy, AlertActionType, String?)>()
-    private let stopUpdatingLocationStream = PublishSubject<AlertActionType>()
+    private let stopUpdatingLocationStream = PublishSubject<Void>()
 
     // MARK: BehaviorSubjects
     private let errorStream = BehaviorSubject<String?>(value: nil)
@@ -126,23 +126,10 @@ extension MapViewModel {
     func observeStopUpdatingLocation(locationManager: CLLocationManager) {
 
         stopUpdatingLocationStream
-            .subscribe { [weak self] event in
-                guard let strongSelf = self, let alertActionType = event.element else { return }
-                switch alertActionType {
-                case .ok:
-                    // 位置情報の計測を停止
-                    locationManager.stopUpdatingLocation()
-                    // 位置情報の計測停止を実行したことをViewに伝える
-                    Observable.just(Void())
-                        .bind(to: strongSelf.doneUpdatingLocationModeDisabledStream)
-                        .disposed(by: strongSelf.disposeBag)
-                case .cancel:
-                    // 位置情報の計測停止をキャンセルしたことをViewに伝える
-                    Observable.just(Void())
-                        .bind(to: strongSelf.cancelUpdatingLocationModeDisabledStream)
-                        .disposed(by: strongSelf.disposeBag)
-                }
-        }.disposed(by: disposeBag)
+            .subscribe { _ in
+                // 位置情報の計測を停止
+                locationManager.stopUpdatingLocation()
+            }.disposed(by: disposeBag)
     }
 }
 
@@ -152,7 +139,7 @@ extension MapViewModel {
     var startUpdatingLocation: AnyObserver<(LocationAccuracy, AlertActionType, String?)> {
         return startUpdatingLocationStream.asObserver()
     }
-    var stopUpdatingLocation: AnyObserver<AlertActionType> {
+    var stopUpdatingLocation: AnyObserver<Void> {
         return stopUpdatingLocationStream.asObserver()
     }
 }
@@ -162,11 +149,5 @@ extension MapViewModel {
 
     var error: Observable<String?> {
         return errorStream.asObservable()
-    }
-    var doneUpdatingLocationModeDisabled: Observable<()> {
-        return doneUpdatingLocationModeDisabledStream.asObservable()
-    }
-    var cancelUpdatingLocationModeDisabled: Observable<()> {
-        return cancelUpdatingLocationModeDisabledStream.asObservable()
     }
 }


### PR DESCRIPTION
#### 実装内容

- `STOP`タップ時の処理の実装
- `START`タップ時の処理の修正
  - `View`/`ViewModel`の責務分け見直し
アラートの`OK`/`Cancel`タップハンドリングは `View` が担うように定義。
`OK`/`Cancel`のタップまでがユーザ操作と見なせるため