### PR TITLE
タブバーのFOOT VIEWの切り替え時に、アノテーションが残り続けるバグがあったので修正

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -607,10 +607,10 @@ struct _R: Rswift.Validatable {
       
       static func validate() throws {
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/footStepMeter/View/MapViewController.swift
+++ b/footStepMeter/View/MapViewController.swift
@@ -82,12 +82,6 @@ extension MapViewController {
                     })
             }
             .disposed(by: disposeBag)
-
-        viewModel.hideLocations
-            .bind { [weak self] _ in
-                guard let strongSelf = self else { return }
-                strongSelf.resetSelectedFootView()
-            }.disposed(by: disposeBag)
     }
 
     // MARK: - Bind to ViewModel
@@ -149,6 +143,13 @@ extension MapViewController {
                 if footprints.count > 0 {
                     strongSelf.putFootprints(footprints)
                 }
+            })
+            .disposed(by: disposeBag)
+
+        viewModel.hideLocations
+            .drive(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.resetSelectedFootView()
             })
             .disposed(by: disposeBag)
     }

--- a/footStepMeter/ViewModel/MapViewModel.swift
+++ b/footStepMeter/ViewModel/MapViewModel.swift
@@ -38,10 +38,10 @@ final class MapViewModel: Injectable {
 
     // MARK: BehaviorSubjects
     private let errorStream = BehaviorSubject<String?>(value: nil)
-    private let hideLocationStream = BehaviorSubject<Void>(value: ())
 
     // MARK: BehaviorRelays
     private let savedLocationStream = BehaviorRelay<[Footprint]>(value: [])
+    private let hideLocationStream = BehaviorRelay<Void>(value: ())
 
     // MARK: Initial method
     init(with dependency: Dependency) {
@@ -160,7 +160,8 @@ extension MapViewModel {
                     // 既に、足跡を表示している(タブバーでFOOT VIEW選択済みの)場合、FOOT VIEW選択解除を指示
                     strongSelf.isShowFootprints = false
                     Observable.just(())
-                        .bind(to: strongSelf.hideLocationStream)
+                        .asDriver(onErrorJustReturn: ())
+                        .drive(strongSelf.hideLocationStream)
                         .disposed(by: strongSelf.disposeBag)
                     return
                 }
@@ -205,8 +206,8 @@ extension MapViewModel {
     var savedLocations: Driver<[Footprint]> {
         return savedLocationStream.asDriver()
     }
-    var hideLocations: Observable<Void> {
-        return hideLocationStream.asObservable()
+    var hideLocations: Driver<Void> {
+        return hideLocationStream.asDriver()
     }
     var error: Observable<String?> {
         return errorStream.asObservable()


### PR DESCRIPTION
refs #25

### バスの理由
- 非表示時にイベントを捕捉できない場合があった
- 表示時は `Driver` を利用して、非表示は `Observable` を利用していたのが良くなかった