### PR TITLE
エラーが連続で発生した場合に、アラートが表示されていなかったバグを修正

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -520,20 +520,29 @@ struct R: Rswift.Validatable {
       fileprivate init() {}
     }
     
-    /// This `R.string.mapView` struct is generated, and contains static references to 4 localization keys.
+    /// This `R.string.mapView` struct is generated, and contains static references to 6 localization keys.
     struct mapView {
       /// Value: タイトルを入力してください。
       static let inputTitleMessage = Rswift.StringResource(key: "inputTitleMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
+      /// Value: 予期せぬエラーが発生しました。
+      static let unExpectedErrorMessage = Rswift.StringResource(key: "unExpectedErrorMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       /// Value: 位置情報の計測を停止しますか？
       static let stopUpdatingLocationMessage = Rswift.StringResource(key: "stopUpdatingLocationMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       /// Value: 位置情報の計測を停止する必要があります。
       static let needToStopUpdatingLocationErrorMessage = Rswift.StringResource(key: "needToStopUpdatingLocationErrorMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       /// Value: 既に同名のタイトルがあります。タイトルを変更してください。
       static let alreadySameTitleErrorMessage = Rswift.StringResource(key: "alreadySameTitleErrorMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
+      /// Value: 表示する足跡がありません。 位置情報を計測してから再度お試しください。
+      static let locationNotExistErrorMessage = Rswift.StringResource(key: "locationNotExistErrorMessage", tableName: "MapView", bundle: R.hostingBundle, locales: [], comment: nil)
       
       /// Value: タイトルを入力してください。
       static func inputTitleMessage(_: Void = ()) -> String {
         return NSLocalizedString("inputTitleMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
+      }
+      
+      /// Value: 予期せぬエラーが発生しました。
+      static func unExpectedErrorMessage(_: Void = ()) -> String {
+        return NSLocalizedString("unExpectedErrorMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
       }
       
       /// Value: 位置情報の計測を停止しますか？
@@ -549,6 +558,11 @@ struct R: Rswift.Validatable {
       /// Value: 既に同名のタイトルがあります。タイトルを変更してください。
       static func alreadySameTitleErrorMessage(_: Void = ()) -> String {
         return NSLocalizedString("alreadySameTitleErrorMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
+      }
+      
+      /// Value: 表示する足跡がありません。 位置情報を計測してから再度お試しください。
+      static func locationNotExistErrorMessage(_: Void = ()) -> String {
+        return NSLocalizedString("locationNotExistErrorMessage", tableName: "MapView", bundle: R.hostingBundle, comment: "")
       }
       
       fileprivate init() {}
@@ -606,11 +620,11 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/footStepMeter/Resources/MapView.strings
+++ b/footStepMeter/Resources/MapView.strings
@@ -5,3 +5,5 @@
 // エラーメッセージ
 "alreadySameTitleErrorMessage" = "既に同名のタイトルがあります。タイトルを変更してください。";
 "needToStopUpdatingLocationErrorMessage" = "位置情報の計測を停止する必要があります。";
+"locationNotExistErrorMessage" = "表示する足跡がありません。\n位置情報を計測してから再度お試しください。";
+"unExpectedErrorMessage" = "予期せぬエラーが発生しました。";

--- a/footStepMeter/View/MapViewController.swift
+++ b/footStepMeter/View/MapViewController.swift
@@ -52,7 +52,6 @@ final class MapViewController: UIViewController, Injectable {
 
         tabBar.selectedItem = nil
 
-        bindFromViewModel()
         bindToViewModel()
         driveFromViewModel()
         driveToViewModel()
@@ -65,24 +64,6 @@ final class MapViewController: UIViewController, Injectable {
 
 // MARK: - Binding Methods
 extension MapViewController {
-
-    // MARK: - Bind from ViewModel
-    private func bindFromViewModel() {
-
-        viewModel.error
-            .bind { [weak self] message in
-                guard let strongSelf = self, let message = message else { return }
-                if message.count == 0 { return }
-                let alert = UIAlertController(title: R.string.common.confirmTitle(),
-                                              message: message,
-                                              preferredStyle: .alert)
-                _ = strongSelf.promptFor(alert: alert)
-                    .subscribe({ _ in
-                        alert.dismiss(animated: false, completion: nil)
-                    })
-            }
-            .disposed(by: disposeBag)
-    }
 
     // MARK: - Bind to ViewModel
     private func bindToViewModel() {
@@ -150,6 +131,21 @@ extension MapViewController {
             .drive(onNext: { [weak self] _ in
                 guard let strongSelf = self else { return }
                 strongSelf.resetSelectedFootView()
+            })
+            .disposed(by: disposeBag)
+
+        viewModel.error
+            .drive(onNext: { [weak self] message in
+                guard let strongSelf = self, let message = message else { return }
+                if message.count == 0 { return }
+                let alert = UIAlertController(title: R.string.common.confirmTitle(),
+                                              message: message,
+                                              preferredStyle: .alert)
+                _ = strongSelf.promptFor(alert: alert)
+                    .subscribe({ _ in
+                        alert.dismiss(animated: false, completion: nil)
+                        strongSelf.tabBar.selectedItem = nil
+                    })
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
refs #28

#### バグの原因
errorStreamをBehaviorSubject型で定義していたことで、`completed`まで流れてしまっており、
後続イベントが発生しても補足してくれなくなってしまっていた。