### PR TITLE
2回連続で位置情報取得の計測開始ができないバグを修正

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -743,11 +743,11 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/footStepMeter/ViewModel/MapViewModel.swift
+++ b/footStepMeter/ViewModel/MapViewModel.swift
@@ -29,11 +29,9 @@ final class MapViewModel: Injectable {
     private (set) var authorized: Driver<Bool>
     private (set) var location: Driver<CLLocationCoordinate2D>
 
-    // MARK: PublishSubjects
-    private let startUpdatingLocationStream = PublishSubject<(LocationAccuracy, String?)>()
-    private let stopUpdatingLocationStream = PublishSubject<Void>()
-
     // MARK: PublishRelays
+    private let startUpdatingLocationStream = PublishRelay<(LocationAccuracy, String?)>()
+    private let stopUpdatingLocationStream = PublishRelay<Void>()
     private let showOrHideSavedLocationsStream = PublishRelay<Void>()
 
     // MARK: BehaviorRelays
@@ -196,11 +194,11 @@ extension MapViewModel {
 // MARK: - Input
 extension MapViewModel {
 
-    var startUpdatingLocation: AnyObserver<(LocationAccuracy, String?)> {
-        return startUpdatingLocationStream.asObserver()
+    var startUpdatingLocation: PublishRelay<(LocationAccuracy, String?)> {
+        return startUpdatingLocationStream
     }
-    var stopUpdatingLocation: AnyObserver<Void> {
-        return stopUpdatingLocationStream.asObserver()
+    var stopUpdatingLocation: PublishRelay<Void> {
+        return stopUpdatingLocationStream
     }
     var showOrHideSavedLocations: PublishRelay<Void> {
         return showOrHideSavedLocationsStream


### PR DESCRIPTION
refs #51 

#### 原因
- PublishSubjectを利用していたため、Eventがcompletedまで流れてしまっていた

#### 対策
- PublishRelayに変更