### PR TITLE
足跡履歴一覧の残りのテストコードを実装

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -780,8 +780,8 @@ struct _R: Rswift.Validatable {
   
   struct nib: Rswift.Validatable {
     static func validate() throws {
-      try _MapViewController.validate()
       try _HistoryMapViewController.validate()
+      try _MapViewController.validate()
     }
     
     struct _AboutAppViewController: Rswift.NibResourceType {
@@ -829,8 +829,8 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Mail", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Mail' is used in nib 'HistoryMapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "ChangeFootprint", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'ChangeFootprint' is used in nib 'HistoryMapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Mail", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Mail' is used in nib 'HistoryMapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }
@@ -847,11 +847,11 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/R.generated.swift
+++ b/R.generated.swift
@@ -780,8 +780,8 @@ struct _R: Rswift.Validatable {
   
   struct nib: Rswift.Validatable {
     static func validate() throws {
-      try _HistoryMapViewController.validate()
       try _MapViewController.validate()
+      try _HistoryMapViewController.validate()
     }
     
     struct _AboutAppViewController: Rswift.NibResourceType {
@@ -847,10 +847,10 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }

--- a/footStepMeterTests/FootprintRecordViewModelTests.swift
+++ b/footStepMeterTests/FootprintRecordViewModelTests.swift
@@ -156,4 +156,31 @@ class FootprintRecordViewModelTests: XCTestCase {
             XCTAssertEqual(event.value.element.unsafelyUnwrapped, expectedItems[key].value.element.unsafelyUnwrapped)
         }
     }
+
+    /// 足跡履歴を削除する時のデータバインディングの確認
+    func testRequestDeleteRecord() {
+        let disposeBag = DisposeBag()
+        let footprintSectionModels = scheduler.createObserver([FootprintRecordSectionModel].self)
+        let isDeleted = scheduler.createObserver(Bool.self)
+        let indexPath = IndexPath(row: 0, section: 0)
+
+        viewModel.savedRecordStream
+            .bind(to: footprintSectionModels)
+            .disposed(by: disposeBag)
+
+        viewModel.completeDeleteRecordStream
+            .bind(to: isDeleted)
+            .disposed(by: disposeBag)
+
+        scheduler.scheduleAt(10) {
+            self.viewModel.requestDeleteRecordStream.accept(indexPath)
+        }
+
+        scheduler.start()
+
+        let expectedItems = [Recorded.next(0, false), Recorded.next(10, true)]
+        for (key, event) in isDeleted.events.enumerated() {
+            XCTAssertEqual(event.value.element.unsafelyUnwrapped, expectedItems[key].value.element.unsafelyUnwrapped)
+        }
+    }
 }

--- a/footStepMeterTests/FootprintRecordViewModelTests.swift
+++ b/footStepMeterTests/FootprintRecordViewModelTests.swift
@@ -121,7 +121,7 @@ class FootprintRecordViewModelTests: XCTestCase {
 
         let items = [("test1", 1), ("test2", 3)]
         let mock = [FootprintRecordSectionModel(items: items)]
-        let expectedItems = [next(0, mock)]
+        let expectedItems = [Recorded.next(0, mock)]
         let element = footprintSectionModels.events.first!.value.element
 
         XCTAssertEqual(element!.first!.items.first!.0, expectedItems.first!.value.element!.first!.items.first!.0)
@@ -130,4 +130,30 @@ class FootprintRecordViewModelTests: XCTestCase {
         XCTAssertEqual(element!.first!.items[1].1, expectedItems.first!.value.element!.first!.items[1].1)
     }
 
+    /// 足跡履歴をマップに描画する画面に遷移時のデータバインディングの確認
+    func testRequestNavigateToHistoryMap() {
+        let disposeBag = DisposeBag()
+        let footprintSectionModels = scheduler.createObserver([FootprintRecordSectionModel].self)
+        let title = scheduler.createObserver(String.self)
+        let indexPath = IndexPath(row: 0, section: 0)
+        
+        viewModel.savedRecordStream
+            .bind(to: footprintSectionModels)
+            .disposed(by: disposeBag)
+        
+        viewModel.completeNavigateToHistoryMapStream
+            .bind(to: title)
+            .disposed(by: disposeBag)
+        
+        scheduler.scheduleAt(10) { [unowned self] in
+            self.viewModel.requestNavigateToHistoryMapStream.accept(indexPath)
+        }
+        
+        scheduler.start()
+        
+        let expectedItems = [Recorded.next(0, ""), Recorded.next(10, "test1")]
+        for (key, event) in title.events.enumerated() {
+            XCTAssertEqual(event.value.element.unsafelyUnwrapped, expectedItems[key].value.element.unsafelyUnwrapped)
+        }
+    }
 }


### PR DESCRIPTION
refs #71 

- requestNavigateToHistoryMapStreamのデータバインディングのテストを追加
- 足跡履歴を削除する時のデータバインディングの確認するテストを追加