### PR TITLE
PickerView表示後のキャンセル処理が未実装だったため対応

### DIFF
--- a/R.generated.swift
+++ b/R.generated.swift
@@ -563,11 +563,11 @@ struct _R: Rswift.Validatable {
       }
       
       static func validate() throws {
-        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Settings", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Settings' is used in nib 'MapViewController', but couldn't be loaded.") }
-        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Start", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Start' is used in nib 'MapViewController', but couldn't be loaded.") }
         if UIKit.UIImage(named: "Stop", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Stop' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "View", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'View' is used in nib 'MapViewController', but couldn't be loaded.") }
+        if UIKit.UIImage(named: "Location", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Image named 'Location' is used in nib 'MapViewController', but couldn't be loaded.") }
         if #available(iOS 11.0, *) {
         }
       }

--- a/footStepMeter/View/Map/MapViewController.swift
+++ b/footStepMeter/View/Map/MapViewController.swift
@@ -100,6 +100,14 @@ extension MapViewController {
                     .disposed(by: strongSelf.disposeBag)
             })
             .disposed(by: disposeBag)
+
+        pickerView?.rx.closePickerView
+            .subscribe({ [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.tabBar.selectedItem = nil
+                strongSelf.activateStartButton()
+            })
+            .disposed(by: disposeBag)
     }
 
     // MARK: - Drive from ViewModel


### PR DESCRIPTION
refs #82 

PickerView表示後のキャンセル処理が未実装だったため、タブバーの選択状態やアクティブ状態が想定外の挙動をしていた